### PR TITLE
audio/msm7x30: Set default sample rate to 48KHz

### DIFF
--- a/AudioHardware.h
+++ b/AudioHardware.h
@@ -27,7 +27,6 @@
 #include <utils/threads.h>
 #include <sys/prctl.h>
 #include <utils/SortedVector.h>
-#include <cutils/properties.h>
 
 #include <hardware_legacy/AudioHardwareBase.h>
 
@@ -362,31 +361,11 @@ private:
                                 int *pFormat,
                                 uint32_t *pChannels,
                                 uint32_t *pRate);
-        virtual uint32_t sampleRate() const {
-            char af_quality[PROPERTY_VALUE_MAX];
-            property_get("af.resampler.quality",af_quality,"0");
-            if(strcmp("4",af_quality) == 0) {
-                ALOGV("SampleRate 48k");
-                return 48000;
-            } else {
-                ALOGV("SampleRate 44.1k");
-                return 44100;
-            }
-        }
-        virtual size_t bufferSize() const {
-            char af_quality[PROPERTY_VALUE_MAX];
-            property_get("af.resampler.quality",af_quality,"0");
-            if(strcmp("4",af_quality) == 0) {
-                ALOGV("Bufsize 5248");
-                return 5248;
-            } else {
-                ALOGV("Bufsize 4800");
-                return 4800;
-            }
-        }
+        virtual uint32_t    sampleRate() const { return 48000; }
+        // must be 32-bit aligned
+        virtual size_t      bufferSize() const { return 5248; }
         virtual uint32_t    channels() const { return AUDIO_CHANNEL_OUT_STEREO; }
         virtual int         format() const { return AUDIO_FORMAT_PCM_16_BIT; }
-
         virtual uint32_t    latency() const { return (1000*AUDIO_HW_NUM_OUT_BUF*(bufferSize()/frameSize()))/sampleRate()+AUDIO_HW_OUT_LATENCY_MS; }
         virtual status_t    setVolume(float left, float right) { return INVALID_OPERATION; }
         virtual ssize_t     write(const void* buffer, size_t bytes);


### PR DESCRIPTION
* af.resampler.quality is not used anymore, force 48KHz since we support it

Change-Id: I5f34eb390c2e6b9c5b8386cb2a53a3e84c69ba69